### PR TITLE
Release v0.6.0 to Production PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gs-batch-pdf"
-version = "0.6.0rc1"
+version = "0.6.0"
 description = "cli tool wrapper for manipulating multiple pdfs file in parallel using ghostscript (compressing, convert to pdfa, etc.)"
 authors = [{ name = "kompre", email = "s.follador@gmail.com" }]
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -126,7 +126,7 @@ wheels = [
 
 [[package]]
 name = "gs-batch-pdf"
-version = "0.6.0rc1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Stabilize pre-release 0.6.0rc1 to stable 0.6.0 for production PyPI release.

## Release Contents

This stable release includes all features from 0.6.0rc1:

### Simplified Release Workflow
- Manual version bumping (developer bumps before PR)  
- Removed complex automatic version bumping (202 lines of code removed)
- Only  label needed (no more bump:* labels)
- Version extracted from pyproject.toml
- Target determined from version string

### New --on-error Option
-  (default): Interactive prompts
- : Skip failed files and continue
- : Stop on first error with exit code 1
- Perfect for CI/CD pipelines and automation

### Documentation Updates
- Updated CONTRIBUTING.md with new release process
- Added agent update notes for future projects
- Comprehensive testing guide

## Testing

✅ All 20 tests passing (16 original + 4 new for --on-error)
✅ Type checking passes (mypy)
✅ Successfully tested on TestPyPI as 0.6.0rc1

## Target

🎯 **Production PyPI** (version is stable, no rc/alpha/beta/dev suffix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)