### PR TITLE
feat: add timeout protection for Ghostscript processing (v0.6.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ gsb *.pdf --compress --pdfa --prefix "processed_"
 
 #### Other Options
 
+- `--timeout INTEGER`: Maximum processing time per file in seconds (default: 300)
+  - Set to `0` to disable timeout protection
+  - Prevents indefinite hangs on problematic PDFs
 - `--open_path` / `--no_open_path`: Open output location in file manager (default: enabled)
 - `-v, --verbose`: Show detailed Ghostscript command output
 - `--version`: Show version information
@@ -258,6 +261,16 @@ Verbose output for debugging:
 gsb document.pdf -v --compress --pdfa
 ```
 
+Process with custom timeout for large files:
+
+```bash
+# Set 10 minute timeout for very large PDFs
+gsb large-document.pdf --compress --timeout 600
+
+# Disable timeout for files that take a long time
+gsb complex-document.pdf --compress --timeout 0
+```
+
 ## Output
 
 After processing completes, gs-batch-pdf displays a detailed summary table:
@@ -312,6 +325,15 @@ If you encounter permission errors when processing files:
 - Use `--prefix` to write to a different directory
 - Check file permissions on both input and output locations
 - On Windows, ensure files aren't open in another program
+
+### Timeout Issues
+
+If processing is hanging or taking too long:
+
+- The default timeout is 5 minutes (300 seconds) per file
+- For large or complex PDFs, increase the timeout: `--timeout 600` (10 minutes)
+- To disable timeout protection: `--timeout 0`
+- Some corrupted PDFs may cause Ghostscript to hang indefinitely - timeout protection will terminate these processes
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gs-batch-pdf"
-version = "0.6.0"
+version = "0.6.1b1"
 description = "cli tool wrapper for manipulating multiple pdfs file in parallel using ghostscript (compressing, convert to pdfa, etc.)"
 authors = [{ name = "kompre", email = "s.follador@gmail.com" }]
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gs-batch-pdf"
-version = "0.6.1b1"
+version = "0.6.1"
 description = "cli tool wrapper for manipulating multiple pdfs file in parallel using ghostscript (compressing, convert to pdfa, etc.)"
 authors = [{ name = "kompre", email = "s.follador@gmail.com" }]
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -126,7 +126,7 @@ wheels = [
 
 [[package]]
 name = "gs-batch-pdf"
-version = "0.6.1b1"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -126,7 +126,7 @@ wheels = [
 
 [[package]]
 name = "gs-batch-pdf"
-version = "0.6.0"
+version = "0.6.1b1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Adds timeout protection to prevent indefinite hangs when processing problematic PDFs with Ghostscript.

## Problem
Found a PDF file (467 pages with transparency, annotations, embedded fonts) that causes Ghostscript to hang indefinitely during finalization after processing all pages. This occurs specifically when using `--compress --pdfa` together.

## Solution
- Added `--timeout` CLI option (default: 300 seconds, set to 0 to disable)
- Implemented timeout checking in the Ghostscript subprocess loop
- Proper process termination on timeout with kill signal
- Updated documentation with timeout troubleshooting section

## Changes
- **gs_batch.py**: 
  - Add timeout parameter to CLI and pass through processing chain
  - Implement timeout loop in `run_ghostscript()` function
  - Check elapsed time on each stdout read iteration
  - Kill process if timeout exceeded
- **README.md**: 
  - Document `--timeout` option
  - Add "Timeout Issues" troubleshooting section with examples
- **Version**: Bumped to 0.6.1

## Testing
- All existing tests pass (20/20)
- Tested with problematic PDF - timeout triggers correctly at 300s
- Tested normal PDFs - no regression in functionality

## Test Plan
- [x] Run full test suite
- [x] Test timeout with hanging PDF
- [x] Test normal processing still works
- [x] Verify timeout=0 disables protection
- [x] Documentation is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)